### PR TITLE
Fix invalid JSON schema creation - empty required array is created

### DIFF
--- a/templates/object.hbs
+++ b/templates/object.hbs
@@ -20,4 +20,6 @@
   {{else}}
     false,
   {{/if}}
-"required": [{{{required properties}}}]
+{{#if (required properties) }}
+  ,"required": [{{{required properties}}}]
+{{/if}}


### PR DESCRIPTION
When object has no required properties, the created JSON schema contains required with empty array for this object.
According to the JSON schema docs, this is invalid 
ref: http://json-schema.org/latest/json-schema-validation.html#anchor61 (see 5.4.3.1)

For example,
Typescript interface:
export class Foo {
    bar: { [key: string]: string };
}

generated JSON schema:
{...
"bar": {
      "type": "object",
      "properties": {},
      "additionalProperties": {
        "type": "string"
      },
      "required": []
    }
}
