### PR TITLE
Fix invalid JSON schema creation - empty required array is created

### DIFF
--- a/templates/object.hbs
+++ b/templates/object.hbs
@@ -16,8 +16,10 @@
 },
 "additionalProperties":
   {{#if stringIndexType}}
-    { {{> type type=stringIndexType}} },
+    { {{> type type=stringIndexType}} }
   {{else}}
-    false,
+    false
   {{/if}}
-"required": [{{{required properties}}}]
+{{#if (required properties) }}
+,"required": [{{{required properties}}}]
+{{/if}}

--- a/test/fixtures/example/indexed1.json
+++ b/test/fixtures/example/indexed1.json
@@ -6,6 +6,5 @@
   "properties": {},
   "additionalProperties": {
     "type": "string"
-  },
-  "required": []
+  }
 }

--- a/test/fixtures/example/indexed2.json
+++ b/test/fixtures/example/indexed2.json
@@ -6,6 +6,5 @@
   "properties": {},
   "additionalProperties": {
     "$ref": "http://example.com/typhen-json-schema/example/some_types.json"
-  },
-  "required": []
+  }
 }

--- a/test/fixtures/example/indexed3.json
+++ b/test/fixtures/example/indexed3.json
@@ -4,6 +4,5 @@
   "description": "",
   "type": "object",
   "properties": {},
-  "additionalProperties": {},
-  "required": []
+  "additionalProperties": {}
 }


### PR DESCRIPTION
When object has no required properties, the created JSON schema contains required with empty array for this object.
According to the JSON schema docs, this is invalid 
ref: http://json-schema.org/latest/json-schema-validation.html#anchor61 (see 5.4.3.1)

For example,
Typescript interface:
export class Foo {
bar: { [key: string]: string };
}

generated JSON schema:
{...
"bar": {
"type": "object",
"properties": {},
"additionalProperties": {
"type": "string"
},
"required": []
}
}
